### PR TITLE
Avoid SearchController naming conflict

### DIFF
--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-import '../../application/search/search_controller.dart';
+import '../../application/search/search_controller.dart' as search;
 import '../../application/core/async_state.dart';
 import '../../domain/entities/search_result.dart';
 import '../../infrastructure/di/locator.dart';
@@ -25,12 +25,12 @@ class _SearchScreenState extends State<SearchScreen> {
   final seatController = TextEditingController();
   DateTime? selectedDateTime;
 
-  late final SearchController controller;
+  late final search.SearchController controller =
+      search.SearchController(locator());
 
   @override
   void initState() {
     super.initState();
-    controller = SearchController(locator());
     controller.addListener(() => setState(() {}));
   }
 


### PR DESCRIPTION
## Summary
- alias app `SearchController` to prevent clashes with Flutter's own `SearchController`
- instantiate controller with prefix for clarity

## Testing
- `flutter analyze lib/presentation/search/search_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689782085fc48329ae4919ce24a3e7dd