### PR TITLE
Enhance UI with animations and transitions

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,8 +8,16 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Swappy',
-      debugShowCheckedModeBanner: false,  
-      theme: ThemeData(primarySwatch: Colors.blue),
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: ZoomPageTransitionsBuilder(),
+            TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+          },
+        ),
+      ),
       initialRoute: '/',
       routes: appRoutes,
     );

--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/main_scaffold.dart';
 import '../widgets/search_form.dart';
 import '../widgets/search_summary.dart';
 import '../widgets/seat_request_dialog.dart';
+import '../widgets/tap_scale.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
@@ -88,6 +89,7 @@ class _SearchScreenState extends State<SearchScreen> {
     final bottomPadding = MediaQuery.of(context).padding.bottom + 16;
     final results = state.data ?? <SearchResult>[];
     final hasSearched = state.status == AsyncStatus.success;
+    final disableAnimations = MediaQuery.of(context).disableAnimations;
 
     return MainScaffold(
       currentIndex: 1,
@@ -106,13 +108,9 @@ class _SearchScreenState extends State<SearchScreen> {
               elevation: 0,
               centerTitle: true,
               automaticallyImplyLeading: false,
-              title: const Text(
-                'Swappy',
-                style: TextStyle(
-                  color: Colors.grey,
-                  fontSize: 20,
-                  fontWeight: FontWeight.w600,
-                ),
+              title: Hero(
+                tag: 'app-logo',
+                child: Image.asset('assets/logo.png', height: 32),
               ),
             ),
             if (state.status == AsyncStatus.idle)
@@ -174,29 +172,44 @@ class _SearchScreenState extends State<SearchScreen> {
                 onEdit: () => controller.state = const AsyncState.idle(),
               ),
             Expanded(
-              child: Builder(
-                builder: (context) {
+              child: AnimatedSwitcher(
+                duration: disableAnimations
+                    ? Duration.zero
+                    : const Duration(milliseconds: 250),
+                switchInCurve: Curves.easeOut,
+                switchOutCurve: Curves.easeIn,
+                child: () {
                   if (state.status == AsyncStatus.loading) {
-                    return const Center(child: CircularProgressIndicator());
+                    return const Center(
+                      key: ValueKey('loading'),
+                      child: CircularProgressIndicator(),
+                    );
                   }
                   if (state.status == AsyncStatus.error) {
                     return Column(
+                      key: const ValueKey('error'),
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         const Text('Something went wrong'),
                         const SizedBox(height: 12),
-                        ElevatedButton(
-                          onPressed: _submitSearch,
-                          child: const Text('Retry'),
+                        TapScale(
+                          child: ElevatedButton(
+                            onPressed: _submitSearch,
+                            child: const Text('Retry'),
+                          ),
                         ),
                       ],
                     );
                   }
                   if (state.status == AsyncStatus.success) {
                     if (results.isEmpty) {
-                      return const Center(child: Text('No results found'));
+                      return const Center(
+                        key: ValueKey('empty'),
+                        child: Text('No results found'),
+                      );
                     }
                     return SafeArea(
+                      key: const ValueKey('search-results'),
                       top: false,
                       child: ListView.builder(
                         padding: EdgeInsets.only(
@@ -208,7 +221,7 @@ class _SearchScreenState extends State<SearchScreen> {
                         itemCount: results.length,
                         itemBuilder: (context, i) {
                           final r = results[i];
-                          return Container(
+                          final item = Container(
                             margin: const EdgeInsets.only(bottom: 12),
                             padding: const EdgeInsets.all(16),
                             decoration: BoxDecoration(
@@ -234,7 +247,8 @@ class _SearchScreenState extends State<SearchScreen> {
                                       children: [
                                         const Icon(
                                           Icons.flight_takeoff,
-                                          color: Color.fromARGB(255, 79, 170, 255),
+                                          color:
+                                              Color.fromARGB(255, 79, 170, 255),
                                         ),
                                         const SizedBox(width: 8),
                                         Text(
@@ -247,14 +261,21 @@ class _SearchScreenState extends State<SearchScreen> {
                                       ],
                                     ),
                                     Column(
-                                      crossAxisAlignment: CrossAxisAlignment.end,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.end,
                                       children: [
-                                        Text(Dates.ymd(r.dateTime),
-                                            style: const TextStyle(
-                                                color: Colors.grey, fontSize: 12)),
-                                        Text(Dates.time.format(r.dateTime),
-                                            style: const TextStyle(
-                                                color: Colors.grey, fontSize: 12)),
+                                        Text(
+                                          Dates.ymd(r.dateTime),
+                                          style: const TextStyle(
+                                              color: Colors.grey,
+                                              fontSize: 12),
+                                        ),
+                                        Text(
+                                          Dates.time.format(r.dateTime),
+                                          style: const TextStyle(
+                                              color: Colors.grey,
+                                              fontSize: 12),
+                                        ),
                                       ],
                                     ),
                                   ],
@@ -268,26 +289,30 @@ class _SearchScreenState extends State<SearchScreen> {
                                       MainAxisAlignment.spaceBetween,
                                   children: [
                                     Text('Seat: ${r.seat}'),
-                                    ElevatedButton.icon(
-                                      onPressed: () =>
-                                          showSeatRequestDialog(context, {
-                                        'airline': r.airline,
-                                        'from': r.from,
-                                        'to': r.to,
-                                        'seat': r.seat,
-                                        'date': Dates.ymd(r.dateTime),
-                                        'time': Dates.time.format(r.dateTime),
-                                      }),
-                                      icon: const Icon(Icons.event_seat),
-                                      label: const Text('Solicitar asiento'),
-                                      style: ElevatedButton.styleFrom(
-                                        backgroundColor:
-                                            AppColors.primary.withOpacity(0.1),
-                                        foregroundColor: AppColors.primary,
-                                        elevation: 0,
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(20),
+                                    TapScale(
+                                      child: ElevatedButton.icon(
+                                        onPressed: () =>
+                                            showSeatRequestDialog(context, {
+                                          'airline': r.airline,
+                                          'from': r.from,
+                                          'to': r.to,
+                                          'seat': r.seat,
+                                          'date': Dates.ymd(r.dateTime),
+                                          'time':
+                                              Dates.time.format(r.dateTime),
+                                        }),
+                                        icon: const Icon(Icons.event_seat),
+                                        label:
+                                            const Text('Solicitar asiento'),
+                                        style: ElevatedButton.styleFrom(
+                                          backgroundColor: AppColors.primary
+                                              .withOpacity(0.1),
+                                          foregroundColor: AppColors.primary,
+                                          elevation: 0,
+                                          shape: RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(20),
+                                          ),
                                         ),
                                       ),
                                     ),
@@ -296,13 +321,15 @@ class _SearchScreenState extends State<SearchScreen> {
                               ],
                             ),
                           );
+                          return _AnimatedResultItem(index: i, child: item);
                         },
                       ),
                     );
                   }
                   return SingleChildScrollView(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    key: const ValueKey('search-form'),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 8),
                     child: Column(
                       children: [
                         SearchForm(
@@ -321,11 +348,58 @@ class _SearchScreenState extends State<SearchScreen> {
                       ],
                     ),
                   );
-                },
+                }(),
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _AnimatedResultItem extends StatefulWidget {
+  final Widget child;
+  final int index;
+
+  const _AnimatedResultItem({required this.child, required this.index});
+
+  @override
+  State<_AnimatedResultItem> createState() => _AnimatedResultItemState();
+}
+
+class _AnimatedResultItemState extends State<_AnimatedResultItem> {
+  bool _visible = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final disable = MediaQuery.of(context).disableAnimations;
+      if (disable) {
+        setState(() => _visible = true);
+      } else {
+        Future.delayed(Duration(milliseconds: widget.index * 50), () {
+          if (mounted) setState(() => _visible = true);
+        });
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = MediaQuery.of(context).disableAnimations
+        ? Duration.zero
+        : const Duration(milliseconds: 300);
+    return AnimatedOpacity(
+      opacity: _visible ? 1 : 0,
+      duration: duration,
+      curve: Curves.easeOut,
+      child: AnimatedSlide(
+        offset: _visible ? Offset.zero : const Offset(0, 0.1),
+        duration: duration,
+        curve: Curves.easeOut,
+        child: widget.child,
       ),
     );
   }

--- a/lib/presentation/widgets/search_form.dart
+++ b/lib/presentation/widgets/search_form.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../constants/app_colors.dart';
 import '../../constants/dates.dart';
+import 'tap_scale.dart';
 
 class SearchForm extends StatelessWidget {
   final GlobalKey<FormState> formKey;
@@ -77,18 +78,20 @@ class SearchForm extends StatelessWidget {
               const SizedBox(height: 24),
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: onSubmit,
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 16),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30),
+                child: TapScale(
+                  child: ElevatedButton(
+                    onPressed: onSubmit,
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                      backgroundColor: AppColors.primary,
                     ),
-                    backgroundColor: AppColors.primary,
-                  ),
-                  child: const Text(
-                    "Search",
-                    style: TextStyle(fontSize: 18, color: Colors.white),
+                    child: const Text(
+                      "Search",
+                      style: TextStyle(fontSize: 18, color: Colors.white),
+                    ),
                   ),
                 ),
               ),

--- a/lib/presentation/widgets/search_summary.dart
+++ b/lib/presentation/widgets/search_summary.dart
@@ -21,36 +21,52 @@ class SearchSummary extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: [
-                  _flatSummaryItem(Icons.location_on, "From: $from"),
-                  _flatSummaryItem(Icons.flight_takeoff, "To: $to"),
-                  if (dateTime != null)
+    final disable = MediaQuery.of(context).disableAnimations;
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: disable ? 1 : 0, end: 1),
+      duration: disable ? Duration.zero : const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+      builder: (context, value, child) {
+        return Opacity(
+          opacity: value,
+          child: Transform.translate(
+            offset: Offset(0, (1 - value) * 8),
+            child: child,
+          ),
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    _flatSummaryItem(Icons.location_on, "From: $from"),
+                    _flatSummaryItem(Icons.flight_takeoff, "To: $to"),
+                    if (dateTime != null)
+                      _flatSummaryItem(
+                          Icons.calendar_today, Dates.date.format(dateTime!)),
+                    if (dateTime != null)
+                      _flatSummaryItem(
+                          Icons.access_time, Dates.time.format(dateTime!)),
                     _flatSummaryItem(
-                        Icons.calendar_today, Dates.date.format(dateTime!)),
-                  if (dateTime != null)
-                    _flatSummaryItem(
-                        Icons.access_time, Dates.time.format(dateTime!)),
-                  _flatSummaryItem(Icons.airline_seat_recline_normal, "Seat: $seat"),
-                ],
+                        Icons.airline_seat_recline_normal, "Seat: $seat"),
+                  ],
+                ),
               ),
             ),
-          ),
-          IconButton(
-            onPressed: onEdit,
-            icon: const Icon(Icons.edit,
-                color: AppColors.primary, size: 20),
-            tooltip: "Edit",
-          ),
-        ],
+            IconButton(
+              onPressed: onEdit,
+              icon: const Icon(Icons.edit,
+                  color: AppColors.primary, size: 20),
+              tooltip: "Edit",
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/tap_scale.dart
+++ b/lib/presentation/widgets/tap_scale.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class TapScale extends StatefulWidget {
+  final Widget child;
+  final Duration duration;
+
+  const TapScale({super.key, required this.child, this.duration = const Duration(milliseconds: 90)});
+
+  @override
+  State<TapScale> createState() => _TapScaleState();
+}
+
+class _TapScaleState extends State<TapScale> {
+  double _scale = 1.0;
+
+  void _animateTo(double target) {
+    if (MediaQuery.of(context).disableAnimations) return;
+    setState(() => _scale = target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (_) => _animateTo(0.97),
+      onPointerUp: (_) => _animateTo(1.0),
+      onPointerCancel: (_) => _animateTo(1.0),
+      child: AnimatedScale(
+        scale: _scale,
+        duration: widget.duration,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../constants/app_colors.dart';
 import '../constants/app_keys.dart';
+import '../presentation/widgets/tap_scale.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
@@ -67,7 +68,10 @@ class _LoginScreenState extends State<LoginScreen> {
         elevation: 0,
         centerTitle: true,
         automaticallyImplyLeading: false,
-        title: Image.asset('assets/swappy.png', height: 32),
+        title: Hero(
+          tag: 'app-logo',
+          child: Image.asset('assets/logo.png', height: 32),
+        ),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
@@ -152,17 +156,20 @@ class _LoginScreenState extends State<LoginScreen> {
                       SizedBox(
                         width: double.infinity,
                         height: 50,
-                        child: ElevatedButton(
-                          onPressed: _submit,
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: AppColors.primary,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(30),
+                        child: TapScale(
+                          child: ElevatedButton(
+                            onPressed: _submit,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(30),
+                              ),
                             ),
-                          ),
-                          child: const Text(
-                            'Entrar',
-                            style: TextStyle(color: Colors.white, fontSize: 16),
+                            child: const Text(
+                              'Entrar',
+                              style:
+                                  TextStyle(color: Colors.white, fontSize: 16),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -12,11 +12,37 @@ class SplashScreen extends StatefulWidget {
   State<SplashScreen> createState() => _SplashScreenState();
 }
 
-class _SplashScreenState extends State<SplashScreen> {
+class _SplashScreenState extends State<SplashScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scaleAnim;
+  late final Animation<double> _fadeAnim;
+
   @override
   void initState() {
     super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
+    _scaleAnim = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutBack,
+    );
+    _fadeAnim = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeIn,
+    );
     _decideNext();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (MediaQuery.of(context).disableAnimations) {
+      _controller.duration = Duration.zero;
+    }
+    _controller.forward();
   }
 
   Future<void> _decideNext() async {
@@ -32,11 +58,27 @@ class _SplashScreenState extends State<SplashScreen> {
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       backgroundColor: AppColors.primary,
       body: Center(
-        child: Image(image: AssetImage('assets/logo.png'), height: 64),
+        child: Hero(
+          tag: 'app-logo',
+          child: FadeTransition(
+            opacity: _fadeAnim,
+            child: ScaleTransition(
+              scale: _scaleAnim,
+              child:
+                  const Image(image: AssetImage('assets/logo.png'), height: 64),
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Animate splash logo with Hero zoom/fade
- Add AnimatedSwitcher and list item animations to search results
- Introduce TapScale widget for tactile feedback and apply to primary buttons
- Configure global page transitions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68979007eb308329992cc96ed4707080