### PR TITLE
feat: add custom page transitions and hero animations

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'routes.dart';
+import 'transitions.dart'; // Added for custom transitions
 
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
@@ -11,10 +12,15 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         primarySwatch: Colors.blue,
+        // Updated to use our custom slide transition globally
         pageTransitionsTheme: const PageTransitionsTheme(
           builders: {
-            TargetPlatform.android: ZoomPageTransitionsBuilder(),
-            TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+            TargetPlatform.android: SlideRightTransitionsBuilder(),
+            TargetPlatform.iOS: SlideRightTransitionsBuilder(),
+            TargetPlatform.macOS: SlideRightTransitionsBuilder(),
+            TargetPlatform.linux: SlideRightTransitionsBuilder(),
+            TargetPlatform.windows: SlideRightTransitionsBuilder(),
+            TargetPlatform.fuchsia: SlideRightTransitionsBuilder(),
           },
         ),
       ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -4,6 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../constants/app_colors.dart';
 import '../constants/app_keys.dart';
 import '../presentation/widgets/tap_scale.dart';
+import '../presentation/search/search_screen.dart'; // Import for navigation
+import '../transitions.dart'; // Custom transitions
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
@@ -36,8 +38,11 @@ class _LoginScreenState extends State<LoginScreen> {
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Sesión iniciada')),
     );
-    // Ir a la home principal (ajusta si prefieres otra)
-    Navigator.pushNamedAndRemoveUntil(context, '/search', (_) => false);
+    // Ir a la home principal con transición fade
+    Navigator.of(context).pushAndRemoveUntil(
+      FadePageRoute(page: const SearchScreen()),
+      (_) => false,
+    );
   }
 
   void _forgotPassword() {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -77,7 +77,11 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
         elevation: 0,
         centerTitle: true,
         automaticallyImplyLeading: false,
-        title: Image.asset('assets/swappy.png', height: 32),
+        // Hero to match register/login logo transitions
+        title: const Hero(
+          tag: 'app-logo',
+          child: Image(image: AssetImage('assets/logo.png'), height: 32),
+        ),
       ),
 
       body: SafeArea(

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -3,6 +3,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../constants/app_colors.dart';
 import '../constants/app_keys.dart';
+import '../transitions.dart'; // Custom transitions
+import 'onboarding_screen.dart'; // Navigate after register
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({Key? key}) : super(key: key);
@@ -42,9 +44,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
   final prefs = await SharedPreferences.getInstance();
   await prefs.setString(AppKeys.authUserId, 'user_demo');
 
-  // Ve al Onboarding post-registro
+  // Ve al Onboarding post-registro con animación scale + fade
   if (!mounted) return;
-  Navigator.pushReplacementNamed(context, '/onboarding');
+  Navigator.of(context).pushReplacement(
+    ScaleFadePageRoute(page: const OnboardingScreen()),
+  );
   }
 
   @override
@@ -56,7 +60,11 @@ class _RegisterScreenState extends State<RegisterScreen> {
         elevation: 0,
         centerTitle: true,
         automaticallyImplyLeading: false,
-        title: Image.asset('assets/swappy.png', height: 32),
+        // Added Hero for shared logo between screens
+        title: const Hero(
+          tag: 'app-logo',
+          child: Image(image: AssetImage('assets/logo.png'), height: 32),
+        ),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),

--- a/lib/transitions.dart
+++ b/lib/transitions.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+// Durations for forward and reverse animations
+const Duration kForwardDuration = Duration(milliseconds: 320);
+const Duration kReverseDuration = Duration(milliseconds: 280);
+
+/// Fade transition route
+class FadePageRoute<T> extends PageRouteBuilder<T> {
+  FadePageRoute({required Widget page})
+      : super(
+          pageBuilder: (context, animation, secondaryAnimation) => page,
+          transitionDuration: kForwardDuration,
+          reverseTransitionDuration: kReverseDuration,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            final curved =
+                CurvedAnimation(parent: animation, curve: Curves.easeOut);
+            return FadeTransition(opacity: curved, child: child);
+          },
+        );
+}
+
+/// Slide from right transition route
+class SlideRightPageRoute<T> extends PageRouteBuilder<T> {
+  SlideRightPageRoute({required Widget page})
+      : super(
+          pageBuilder: (context, animation, secondaryAnimation) => page,
+          transitionDuration: kForwardDuration,
+          reverseTransitionDuration: kReverseDuration,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            final curved =
+                CurvedAnimation(parent: animation, curve: Curves.easeOut);
+            return SlideTransition(
+              position: Tween<Offset>(
+                      begin: const Offset(1.0, 0.0), end: Offset.zero)
+                  .animate(curved),
+              child: child,
+            );
+          },
+        );
+}
+
+/// Scale + Fade transition with easeOutBack curve
+class ScaleFadePageRoute<T> extends PageRouteBuilder<T> {
+  ScaleFadePageRoute({required Widget page})
+      : super(
+          pageBuilder: (context, animation, secondaryAnimation) => page,
+          transitionDuration: kForwardDuration,
+          reverseTransitionDuration: kReverseDuration,
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            final scale = CurvedAnimation(
+              parent: animation,
+              curve: Curves.easeOutBack,
+            );
+            final fade =
+                CurvedAnimation(parent: animation, curve: Curves.easeOut);
+            return FadeTransition(
+              opacity: fade,
+              child: ScaleTransition(scale: scale, child: child),
+            );
+          },
+        );
+}
+
+/// Builder used for the global [pageTransitionsTheme]
+class SlideRightTransitionsBuilder extends PageTransitionsBuilder {
+  const SlideRightTransitionsBuilder();
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final curved = CurvedAnimation(parent: animation, curve: Curves.easeOut);
+    return SlideTransition(
+      position:
+          Tween<Offset>(begin: const Offset(1.0, 0.0), end: Offset.zero)
+              .animate(curved),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable fade, slide-right, and scale-fade page routes
- apply custom slide-right transitions globally
- animate logo between screens with Hero widgets

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a97637548329bf672aa70543959f