### PR TITLE
feat: add responsive utilities and adaptive navigation

### DIFF
--- a/lib/core/responsive/responsive.dart
+++ b/lib/core/responsive/responsive.dart
@@ -1,0 +1,49 @@
+// Responsive utilities for Swappy
+// Defines breakpoints, size classes, and spacing helpers.
+
+import 'package:flutter/material.dart';
+
+/// Breakpoints used across the app.
+class Breakpoints {
+  static const double phone = 0;        // up to 599
+  static const double tablet = 600;     // 600–1023
+  static const double desktop = 1024;   // 1024+
+}
+
+/// Size classes representing the current screen width.
+enum SizeClass { phone, tablet, desktop }
+
+/// Extension helpers to easily query responsive information from [BuildContext].
+extension ResponsiveContext on BuildContext {
+  Size get screenSize => MediaQuery.sizeOf(this);
+  double get width => screenSize.width;
+  double get height => screenSize.height;
+
+  /// Returns the [SizeClass] for the current width.
+  SizeClass get sizeClass {
+    final w = width;
+    if (w >= Breakpoints.desktop) return SizeClass.desktop;
+    if (w >= Breakpoints.tablet) return SizeClass.tablet;
+    return SizeClass.phone;
+  }
+
+  bool get isPhone => sizeClass == SizeClass.phone;
+  bool get isTablet => sizeClass == SizeClass.tablet;
+  bool get isDesktop => sizeClass == SizeClass.desktop;
+}
+
+/// Returns the base space used between components.
+/// Scales with the current [SizeClass].
+double space(BuildContext c) =>
+    c.isDesktop ? 24 : c.isTablet ? 16 : 12;
+
+/// Returns the outer gutter/padding value for pages.
+/// Scales with the current [SizeClass].
+double gutter(BuildContext c) =>
+    c.isDesktop ? 32 : c.isTablet ? 24 : 16;
+
+/// Responsive headline style adapting to the current width.
+TextStyle headline(BuildContext c, ThemeData t) =>
+    t.textTheme.headlineSmall!.copyWith(
+      fontSize: c.isDesktop ? 28 : c.isTablet ? 24 : 20,
+    );

--- a/lib/presentation/widgets/main_scaffold.dart
+++ b/lib/presentation/widgets/main_scaffold.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:curved_navigation_bar/curved_navigation_bar.dart';
 
+import 'package:swappy/core/responsive/responsive.dart';
 
 class MainScaffold extends StatefulWidget {
   final int currentIndex;
@@ -41,28 +42,60 @@ class _MainScaffoldState extends State<MainScaffold> {
   Color _iconColor(int idx) =>
       _currentIndex == idx ? Colors.white : Colors.grey;
 
+  List<NavigationRailDestination> get _railDestinations => const [
+        NavigationRailDestination(
+          icon: Icon(Icons.notifications),
+          label: Text('Notificaciones'),
+        ),
+        NavigationRailDestination(
+          icon: Icon(Icons.search),
+          label: Text('Buscar'),
+        ),
+        NavigationRailDestination(
+          icon: Icon(Icons.person),
+          label: Text('Perfil'),
+        ),
+      ];
+
   @override
   Widget build(BuildContext context) {
+    final fab = Padding(
+      padding: const EdgeInsets.only(bottom: 20.0),
+      child: FloatingActionButton(
+        onPressed: _goToCreate,
+        backgroundColor: Colors.blue,
+        tooltip: 'Publicar anuncio',
+        child: const Icon(Icons.add, color: Colors.white),
+      ),
+    );
+
+    // Use a NavigationRail on larger screens and a curved bottom bar on phones.
+    if (context.isTablet || context.isDesktop) {
+      return Scaffold(
+        backgroundColor: Colors.white,
+        floatingActionButton: fab,
+        floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+        body: Row(
+          children: [
+            NavigationRail(
+              selectedIndex: _currentIndex,
+              destinations: _railDestinations,
+              onDestinationSelected: _onTap,
+              labelType: NavigationRailLabelType.selected,
+            ),
+            const VerticalDivider(width: 1),
+            Expanded(child: widget.child),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       extendBody: true,
       backgroundColor: Colors.white,
-
-      // tu contenido variable
       body: widget.child,
-
-      // FAB común
-      floatingActionButton: Padding(
-        padding: const EdgeInsets.only(bottom: 20.0),
-        child: FloatingActionButton(
-          onPressed: _goToCreate,
-          backgroundColor: Colors.blue,
-          tooltip: 'Publicar anuncio',
-          child: const Icon(Icons.add, color: Colors.white),
-        ),
-      ),
+      floatingActionButton: fab,
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-
-      // barra curva
       bottomNavigationBar: CurvedNavigationBar(
         index: _currentIndex,
         height: 75,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 
+import 'package:swappy/core/responsive/responsive.dart';
 import 'package:swappy/presentation/widgets/main_scaffold.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -12,87 +13,123 @@ class ProfileScreen extends StatelessWidget {
     return MainScaffold(
       currentIndex: 2,
       child: SafeArea(
-        child: Column(
-          children: [
-            // ► AppBar blanco con texto e iconos grises
-            AppBar(
-              backgroundColor: Colors.white,
-              elevation: 0,
-              centerTitle: true,
-              automaticallyImplyLeading: false,
-              title: const Text(
-                'Perfil',
-                style: TextStyle(
-                  color: Colors.grey,
-                  fontSize: 15,
-                  fontWeight: FontWeight.w200,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final isWide = constraints.maxWidth >= Breakpoints.tablet;
+
+            // Header with avatar and name.
+            final header = Column(
+              children: [
+                const CircleAvatar(
+                  radius: 48,
+                  backgroundImage: AssetImage('assets/avatar.png'),
                 ),
-              ),
-              actions: [
-                IconButton(
-                  icon: const Icon(Icons.person),
-                  color: Colors.grey,
-                  onPressed: () {},
+                SizedBox(height: space(context)),
+                const Text(
+                  'Adriano',
+                  style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
                 ),
-                const SizedBox(width: 8),
+                SizedBox(height: space(context) / 2),
+                Text(
+                  'Viajero estrella',
+                  style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
+                ),
               ],
-            ),
+            );
 
-            const SizedBox(height: 24),
+            // Options list reused in both layouts.
+            final options = <Widget>[
+              _OptionTile(
+                icon: Icons.list_alt,
+                label: 'Anuncios publicados',
+                onTap: () => Navigator.pushNamed(context, '/published_listings'),
+              ),
+              _OptionTile(
+                icon: Icons.edit,
+                label: 'Editar perfil',
+                onTap: () => Navigator.pushNamed(context, '/edit_profile'),
+              ),
+              _OptionTile(
+                icon: Icons.notifications,
+                label: 'Configurar notificaciones',
+                onTap: () => Navigator.pushNamed(context, '/notifications_settings'),
+              ),
+              _OptionTile(
+                icon: Icons.report_problem,
+                label: 'Reportar un problema',
+                onTap: () => Navigator.pushNamed(context, '/report_problem'),
+              ),
+              _OptionTile(
+                icon: Icons.info,
+                label: 'Sobre la app',
+                onTap: () => Navigator.pushNamed(context, '/about_app'),
+              ),
+              _OptionTile(
+                icon: Icons.logout,
+                label: 'Cerrar sesión',
+                onTap: () => _showLogoutDialog(context),
+              ),
+            ];
 
-            // ► Avatar y nombre
-            const CircleAvatar(
-              radius: 48,
-              backgroundImage: AssetImage("assets/avatar.png"),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              'Adriano',
-              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 4),
-            Text(
-              'Viajero estrella',
-              style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
-            ),
+            Widget content;
+            if (isWide) {
+              content = Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(flex: 2, child: header),
+                  SizedBox(width: space(context)),
+                  Expanded(
+                    flex: 3,
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: options,
+                    ),
+                  ),
+                ],
+              );
+            } else {
+              content = ListView(
+                padding: EdgeInsets.zero,
+                children: [
+                  header,
+                  SizedBox(height: space(context) * 2),
+                  ...options,
+                ],
+              );
+            }
 
-            const SizedBox(height: 32),
-
-            // ► Opciones
-            _OptionTile(
-              icon: Icons.list_alt,
-              label: 'Anuncios publicados',
-              onTap: () => Navigator.pushNamed(context, '/published_listings'),
-            ),
-            _OptionTile(
-              icon: Icons.edit,
-              label: 'Editar perfil',
-              onTap: () => Navigator.pushNamed(context, '/edit_profile'),
-            ),
-            _OptionTile(
-              icon: Icons.notifications,
-              label: 'Configurar notificaciones',
-              onTap: () =>
-                  Navigator.pushNamed(context, '/notifications_settings'),
-            ),
-            _OptionTile(
-              icon: Icons.report_problem,
-              label: 'Reportar un problema',
-              onTap: () => Navigator.pushNamed(context, '/report_problem'),
-            ),
-            _OptionTile(
-              icon: Icons.info,
-              label: 'Sobre la app',
-              onTap: () => Navigator.pushNamed(context, '/about_app'),
-            ),
-            _OptionTile(
-              icon: Icons.logout,
-              label: 'Cerrar sesión',
-              onTap: () => _showLogoutDialog(context),
-            ),
-
-            const Spacer(),
-          ],
+            return Padding(
+              padding: EdgeInsets.all(gutter(context)),
+              child: Column(
+                children: [
+                  AppBar(
+                    backgroundColor: Colors.white,
+                    elevation: 0,
+                    centerTitle: true,
+                    automaticallyImplyLeading: false,
+                    title: const Text(
+                      'Perfil',
+                      style: TextStyle(
+                        color: Colors.grey,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w200,
+                      ),
+                    ),
+                    actions: [
+                      IconButton(
+                        icon: const Icon(Icons.person),
+                        color: Colors.grey,
+                        onPressed: () {},
+                      ),
+                      SizedBox(width: space(context)),
+                    ],
+                  ),
+                  SizedBox(height: space(context) * 2),
+                  Expanded(child: content),
+                ],
+              ),
+            );
+          },
         ),
       ),
     );
@@ -136,7 +173,7 @@ class _OptionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       leading: Container(
-        padding: const EdgeInsets.all(8),
+        padding: EdgeInsets.all(space(context) / 1.5),
         decoration: BoxDecoration(
           color: Colors.blue.withOpacity(0.1),
           borderRadius: BorderRadius.circular(8),
@@ -145,8 +182,8 @@ class _OptionTile extends StatelessWidget {
       ),
       title: Text(label, style: const TextStyle(fontWeight: FontWeight.w500)),
       onTap: onTap,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-      horizontalTitleGap: 16,
+      contentPadding: EdgeInsets.symmetric(horizontal: gutter(context) / 2),
+      horizontalTitleGap: space(context),
     );
   }
 }

--- a/test/presentation/main_scaffold_responsive_test.dart
+++ b/test/presentation/main_scaffold_responsive_test.dart
@@ -1,0 +1,35 @@
+import 'package:curved_navigation_bar/curved_navigation_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swappy/presentation/widgets/main_scaffold.dart';
+
+Future<void> _pump(WidgetTester tester, double width) async {
+  await tester.binding.setSurfaceSize(Size(width, 800));
+  await tester.pumpWidget(
+    MaterialApp(
+      home: MainScaffold(currentIndex: 0, child: const SizedBox()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('uses bottom navigation on phone', (tester) async {
+    await _pump(tester, 390);
+    expect(find.byType(CurvedNavigationBar), findsOneWidget);
+    expect(find.byType(NavigationRail), findsNothing);
+  });
+
+  testWidgets('uses navigation rail on tablet', (tester) async {
+    await _pump(tester, 840);
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(CurvedNavigationBar), findsNothing);
+  });
+
+  testWidgets('uses navigation rail on desktop', (tester) async {
+    await _pump(tester, 1200);
+    expect(find.byType(NavigationRail), findsOneWidget);
+    expect(find.byType(CurvedNavigationBar), findsNothing);
+  });
+}

--- a/test/presentation/profile_screen_responsive_test.dart
+++ b/test/presentation/profile_screen_responsive_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:swappy/screens/profile_screen.dart';
+
+Future<void> _pump(WidgetTester tester, double width) async {
+  await tester.binding.setSurfaceSize(Size(width, 800));
+  await tester.pumpWidget(const MaterialApp(home: ProfileScreen()));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('uses column layout on phone', (tester) async {
+    await _pump(tester, 390);
+    // In phone layout the content is wrapped in a ListView (column-like)
+    expect(find.byType(ListView), findsOneWidget);
+    expect(find.byType(Row), findsNothing);
+  });
+
+  testWidgets('uses row layout on wide screens', (tester) async {
+    await _pump(tester, 840);
+    expect(find.byType(Row), findsWidgets);
+  });
+
+  testWidgets('row layout persists on desktop', (tester) async {
+    await _pump(tester, 1200);
+    expect(find.byType(Row), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- add responsive utilities with breakpoints, context helpers, and spacing/typography scale
- adapt MainScaffold to switch between curved bottom navigation and NavigationRail based on width
- refactor ProfileScreen with LayoutBuilder to support stacked and side-by-side layouts
- add widget tests covering phone, tablet, and desktop widths

## Testing
- `dart format lib/core/responsive/responsive.dart lib/presentation/widgets/main_scaffold.dart lib/screens/profile_screen.dart test/presentation/main_scaffold_responsive_test.dart test/presentation/profile_screen_responsive_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git -b stable --depth 1` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897ba7c5b38832995aacc2b87019b99