### PR TITLE
Refactor search results list to use entity objects

### DIFF
--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -14,6 +14,7 @@ import '../widgets/adaptive_scaffold.dart';
 import '../widgets/search_form.dart';
 import '../widgets/search_summary.dart';
 import '../widgets/seat_request_dialog.dart';
+import '../../widgets/search_results_list.dart';
 import '../../ui/spacing.dart';
 import '../../ui/max_width.dart';
 import '../../ui/states/loading_state.dart';
@@ -233,124 +234,27 @@ class _SearchScreenState extends State<SearchScreen> {
                     }
                     return SafeArea(
                       top: false,
-                      child: ListView.builder(
+                      child: ListView(
                         padding: EdgeInsets.only(
                           left: spaceM,
                           right: spaceM,
                           top: spaceS,
                           bottom: bottomPadding,
                         ),
-                        itemCount: results.length,
-                        itemBuilder: (context, i) {
-                          final r = results[i];
-                          return Container(
-                            margin: const EdgeInsets.only(
-                              bottom: spaceS + spaceXS,
-                            ),
-                            padding: const EdgeInsets.all(spaceM),
-                            decoration: BoxDecoration(
-                              color: Colors.white,
-                              borderRadius: BorderRadius.circular(spaceM),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.black.withOpacity(0.05),
-                                  spreadRadius: 2,
-                                  blurRadius: 8,
-                                  offset: const Offset(0, 4),
-                                ),
-                              ],
-                            ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Row(
-                                      children: [
-                                        const Icon(
-                                          Icons.flight_takeoff,
-                                          color: Color.fromARGB(
-                                            255,
-                                            79,
-                                            170,
-                                            255,
-                                          ),
-                                        ),
-                                        const SizedBox(width: spaceS),
-                                        Text(
-                                          '${r.from} → ${r.to}',
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodyLarge
-                                              ?.copyWith(
-                                                fontWeight: FontWeight.bold,
-                                              ),
-                                        ),
-                                      ],
-                                    ),
-                                    Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.end,
-                                      children: [
-                                        Text(
-                                          Dates.ymd(r.dateTime),
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodyMedium
-                                              ?.copyWith(
-                                                color: Colors.grey,
-                                                fontSize: 12,
-                                              ),
-                                        ),
-                                        Text(
-                                          Dates.time.format(r.dateTime),
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodyMedium
-                                              ?.copyWith(
-                                                color: Colors.grey,
-                                                fontSize: 12,
-                                              ),
-                                        ),
-                                      ],
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: spaceS),
-                                Text(
-                                  r.airline,
-                                  style: Theme.of(context).textTheme.bodyMedium
-                                      ?.copyWith(color: Colors.grey),
-                                ),
-                                const Divider(height: spaceM + spaceS),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text('Seat: ${r.seat}'),
-                                    ElevatedButton.icon(
-                                      onPressed: () =>
-                                          showSeatRequestDialog(context, {
-                                            'airline': r.airline,
-                                            'from': r.from,
-                                            'to': r.to,
-                                            'seat': r.seat,
-                                            'date': Dates.ymd(r.dateTime),
-                                            'time': Dates.time.format(
-                                              r.dateTime,
-                                            ),
-                                          }),
-                                      icon: const Icon(Icons.event_seat),
-                                      label: const Text('Solicitar asiento'),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          );
-                        },
+                        children: [
+                          SearchResultsList(
+                            results: results,
+                            onRequestSeat: (r) =>
+                                showSeatRequestDialog(context, {
+                              'airline': r.airline,
+                              'from': r.from,
+                              'to': r.to,
+                              'seat': r.seat,
+                              'date': Dates.ymd(r.dateTime),
+                              'time': Dates.time.format(r.dateTime),
+                            }),
+                          ),
+                        ],
                       ),
                     );
                   }

--- a/lib/widgets/search_results_list.dart
+++ b/lib/widgets/search_results_list.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 
+import '../constants/dates.dart';
+import '../domain/entities/search_result.dart';
+
 class SearchResultsList extends StatelessWidget {
-  final List<Map<String, String>> results;
-  final Function(Map<String, String>) onRequestSeat;
+  final List<SearchResult> results;
+  final void Function(SearchResult) onRequestSeat;
 
   const SearchResultsList({
     super.key,
@@ -28,7 +31,7 @@ class SearchResultsList extends StatelessWidget {
               BoxShadow(
                 color: Colors.black12,
                 blurRadius: 10,
-                offset: Offset(0, 4),
+                offset: const Offset(0, 4),
               ),
             ],
           ),
@@ -47,14 +50,14 @@ class SearchResultsList extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            "${result['from']} → ${result['to']}",
+                            "${result.from} → ${result.to}",
                             style: const TextStyle(
                               fontSize: 16,
                               fontWeight: FontWeight.bold,
                             ),
                           ),
                           Text(
-                            result['airline'] ?? '',
+                            result.airline,
                             style: const TextStyle(
                               fontSize: 14,
                               color: Colors.black54,
@@ -67,11 +70,11 @@ class SearchResultsList extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
                         Text(
-                          result['date'] ?? '',
+                          Dates.ymd(result.dateTime),
                           style: const TextStyle(color: Colors.black54),
                         ),
                         Text(
-                          result['time'] ?? '--:--',
+                          Dates.time.format(result.dateTime),
                           style: const TextStyle(color: Colors.black54),
                         ),
                       ],
@@ -83,7 +86,7 @@ class SearchResultsList extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      "Seat: ${result['seat']}",
+                      "Seat: ${result.seat}",
                       style: const TextStyle(fontWeight: FontWeight.w500),
                     ),
                     ElevatedButton.icon(


### PR DESCRIPTION
## Summary
- Accept `List<SearchResult>` in `SearchResultsList` and render fields directly
- Update `SearchScreen` to pass `SearchResult` objects to the list widget

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a3efeb20832994a695e1fe5e5487