### PR TITLE
refactor: use prefix icons for search and listing inputs

### DIFF
--- a/lib/presentation/listing/create_listing_screen.dart
+++ b/lib/presentation/listing/create_listing_screen.dart
@@ -52,69 +52,62 @@ class _CreateListingScreenState extends State<CreateListingScreen> {
     }
   }
 
-  Widget _iconBox(IconData icon) {
-    return Container(
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: Colors.blue.withOpacity(0.1),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Icon(icon, color: Colors.blue),
-    );
-  }
-
   Widget _inputTile(String label, IconData icon, TextEditingController c) {
-    return Row(
-      children: [
-        _iconBox(icon),
-        const SizedBox(width: 12),
-        Expanded(
-          child: TextFormField(
-            controller: c,
-            decoration: InputDecoration(
-              labelText: label,
-              filled: true,
-              fillColor: Colors.grey[100],
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(16),
-                borderSide: BorderSide.none,
-              ),
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            ),
-            validator: (v) => v == null || v.isEmpty ? 'Required' : null,
-          ),
+    return TextFormField(
+      controller: c,
+      decoration: InputDecoration(
+        labelText: label,
+        filled: true,
+        fillColor: Colors.grey[100],
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide.none,
         ),
-      ],
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        prefixIcon: Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: Colors.blue.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(icon, color: Colors.blue),
+        ),
+        prefixIconConstraints:
+            const BoxConstraints(minWidth: 0, minHeight: 0),
+      ),
+      validator: (v) => v == null || v.isEmpty ? 'Required' : null,
     );
   }
 
   Widget _dateTimeTile(
       String label, IconData icon, String value, VoidCallback onTap) {
-    return Row(
-      children: [
-        _iconBox(icon),
-        const SizedBox(width: 12),
-        Expanded(
-          child: GestureDetector(
-            onTap: onTap,
-            child: InputDecorator(
-              decoration: InputDecoration(
-                labelText: label,
-                filled: true,
-                fillColor: Colors.grey[100],
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(16),
-                  borderSide: BorderSide.none,
-                ),
-                contentPadding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              ),
-              child: Text(value),
-            ),
+    return GestureDetector(
+      onTap: onTap,
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          filled: true,
+          fillColor: Colors.grey[100],
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
           ),
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          prefixIcon: Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: Colors.blue.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(icon, color: Colors.blue),
+          ),
+          prefixIconConstraints:
+              const BoxConstraints(minWidth: 0, minHeight: 0),
         ),
-      ],
+        child: Text(value),
+      ),
     );
   }
 

--- a/lib/presentation/widgets/search_form.dart
+++ b/lib/presentation/widgets/search_form.dart
@@ -102,72 +102,65 @@ class SearchForm extends StatelessWidget {
     String label,
     TextEditingController controller,
   ) {
-    return Row(
-      children: [
-        _iconBox(icon),
-        const SizedBox(width: spaceS + spaceXS),
-        Expanded(
-          child: TextFormField(
-            controller: controller,
-            decoration: InputDecoration(
-              labelText: label,
-              filled: true,
-              fillColor: Colors.grey[100],
-              contentPadding: const EdgeInsets.symmetric(
-                horizontal: spaceM,
-                vertical: spaceS + spaceXS,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(spaceM),
-                borderSide: BorderSide.none,
-              ),
-            ),
-            validator: (value) =>
-                value == null || value.isEmpty ? 'Required' : null,
-          ),
+    return TextFormField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        filled: true,
+        fillColor: Colors.grey[100],
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: spaceM,
+          vertical: spaceS + spaceXS,
         ),
-      ],
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(spaceM),
+          borderSide: BorderSide.none,
+        ),
+        prefixIcon: Container(
+          padding: const EdgeInsets.all(spaceS + spaceXS),
+          decoration: BoxDecoration(
+            color: AppColors.primary.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(spaceS + spaceXS),
+          ),
+          child: Icon(icon, color: AppColors.primary),
+        ),
+        prefixIconConstraints:
+            const BoxConstraints(minWidth: 0, minHeight: 0),
+      ),
+      validator: (value) =>
+          value == null || value.isEmpty ? 'Required' : null,
     );
   }
 
   Widget _dateTimeTile(IconData icon, String label, String value) {
-    return Row(
-      children: [
-        _iconBox(icon),
-        const SizedBox(width: spaceS + spaceXS),
-        Expanded(
-          child: GestureDetector(
-            onTap: onPickDateTime,
-            child: InputDecorator(
-              decoration: InputDecoration(
-                labelText: label,
-                filled: true,
-                fillColor: Colors.grey[100],
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: spaceM,
-                  vertical: spaceS + spaceXS,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(spaceM),
-                  borderSide: BorderSide.none,
-                ),
-              ),
-              child: Text(value),
-            ),
+    return GestureDetector(
+      onTap: onPickDateTime,
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          filled: true,
+          fillColor: Colors.grey[100],
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: spaceM,
+            vertical: spaceS + spaceXS,
           ),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(spaceM),
+            borderSide: BorderSide.none,
+          ),
+          prefixIcon: Container(
+            padding: const EdgeInsets.all(spaceS + spaceXS),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(spaceS + spaceXS),
+            ),
+            child: Icon(icon, color: AppColors.primary),
+          ),
+          prefixIconConstraints:
+              const BoxConstraints(minWidth: 0, minHeight: 0),
         ),
-      ],
-    );
-  }
-
-  Widget _iconBox(IconData icon) {
-    return Container(
-      padding: const EdgeInsets.all(spaceS + spaceXS),
-      decoration: BoxDecoration(
-        color: AppColors.primary.withOpacity(0.1),
-        borderRadius: BorderRadius.circular(spaceS + spaceXS),
+        child: Text(value),
       ),
-      child: Icon(icon, color: AppColors.primary),
     );
   }
 }


### PR DESCRIPTION
## Summary
- simplify listing creation inputs by using TextFormField with prefix icons
- streamline search form inputs and datetime tiles without extra rows

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b4305e948329b2aeaa464666f1ca