### PR TITLE
Optimize search results list rebuilds

### DIFF
--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -99,7 +99,6 @@ class _SearchScreenState extends State<SearchScreen> {
     return Consumer<search.SearchController>(
       builder: (context, controller, _) {
         final state = controller.state;
-        final results = state.data ?? <SearchResult>[];
         final hasSearched = state.status == AsyncStatus.success;
 
         return AdaptiveScaffold(
@@ -233,36 +232,41 @@ class _SearchScreenState extends State<SearchScreen> {
                     );
                   }
                   if (state.status == AsyncStatus.success) {
-                    if (results.isEmpty) {
-                      return const EmptyState(
-                        icon: Icons.search_off,
-                        title: 'No results found',
-                        subtitle: 'Try a different search',
-                      );
-                    }
                     return SafeArea(
                       top: false,
-                      child: ListView(
-                        padding: EdgeInsets.only(
-                          left: spaceM,
-                          right: spaceM,
-                          top: spaceS,
-                          bottom: bottomPadding,
-                        ),
-                        children: [
-                          SearchResultsList(
-                            results: results,
-                            onRequestSeat: (r) =>
-                                showSeatRequestDialog(context, {
-                              'airline': r.airline,
-                              'from': r.from,
-                              'to': r.to,
-                              'seat': r.seat,
-                              'date': Dates.ymd(r.dateTime),
-                              'time': Dates.time.format(r.dateTime),
-                            }),
-                          ),
-                        ],
+                      child: Selector<search.SearchController, List<SearchResult>>(
+                        selector: (_, c) => c.state.data ?? <SearchResult>[],
+                        builder: (context, results, _) {
+                          if (results.isEmpty) {
+                            return const EmptyState(
+                              icon: Icons.search_off,
+                              title: 'No results found',
+                              subtitle: 'Try a different search',
+                            );
+                          }
+                          return ListView(
+                            padding: EdgeInsets.only(
+                              left: spaceM,
+                              right: spaceM,
+                              top: spaceS,
+                              bottom: bottomPadding,
+                            ),
+                            children: [
+                              SearchResultsList(
+                                results: results,
+                                onRequestSeat: (r) =>
+                                    showSeatRequestDialog(context, {
+                                  'airline': r.airline,
+                                  'from': r.from,
+                                  'to': r.to,
+                                  'seat': r.seat,
+                                  'date': Dates.ymd(r.dateTime),
+                                  'time': Dates.time.format(r.dateTime),
+                                }),
+                              ),
+                            ],
+                          );
+                        },
                       ),
                     );
                   }

--- a/lib/widgets/search_results_list.dart
+++ b/lib/widgets/search_results_list.dart
@@ -15,23 +15,24 @@ class SearchResultsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
+    return ListView.separated(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: results.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 16),
       itemBuilder: (context, index) {
         final result = results[index];
 
         return Container(
-          margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-          decoration: BoxDecoration(
-            color: const Color.fromARGB(255, 249, 254, 255),
-            borderRadius: BorderRadius.circular(16),
+          margin: const EdgeInsets.symmetric(horizontal: 8),
+          decoration: const BoxDecoration(
+            color: Color.fromARGB(255, 249, 254, 255),
+            borderRadius: BorderRadius.all(Radius.circular(16)),
             boxShadow: [
               BoxShadow(
                 color: Colors.black12,
                 blurRadius: 10,
-                offset: const Offset(0, 4),
+                offset: Offset(0, 4),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- Rebuild search results list only when controller state changes using `Selector`
- Switch results rendering to `ListView.separated` with more `const` constructors for widget caching

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/widgets/search_results_list.dart lib/presentation/search/search_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7016fe48329a42985601d8b0f88