### PR TITLE
chore: register AppState and search services in locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Dependencies
+
+This project uses a service-locator approach powered by
+[`get_it`](https://pub.dev/packages/get_it) and
+[`provider`](https://pub.dev/packages/provider) for state management.
+Core services are registered in `lib/infrastructure/di/locator.dart`:
+
+- `AppStateController` – global application state.
+- `AuthService` – authentication wrapper around Firebase.
+- `SearchRepository` – mock data source used by `SearchController`.
+- `SearchController` – manages search queries.
+
+Contributors should register new repositories or services in the locator and
+access them with `locator<T>()` when needed.

--- a/lib/infrastructure/di/locator.dart
+++ b/lib/infrastructure/di/locator.dart
@@ -1,12 +1,16 @@
 import 'package:get_it/get_it.dart';
 
 import '../../domain/repositories/search_repository.dart';
+import '../../application/app_state_controller.dart';
+import '../../application/search/search_controller.dart';
 import '../repositories/mock_search_repository.dart';
 import '../auth/auth_service.dart';
 
 final locator = GetIt.instance;
 
 void setupLocator() {
+  locator.registerLazySingleton<AppStateController>(() => AppStateController());
   locator.registerLazySingleton<SearchRepository>(() => MockSearchRepository());
   locator.registerLazySingleton<AuthService>(() => FirebaseAuthService());
+  locator.registerFactory<SearchController>(() => SearchController(locator()));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,8 +13,8 @@ void main() async {
   );
   setupLocator();
   runApp(
-    ChangeNotifierProvider(
-      create: (_) => AppStateController(),
+    ChangeNotifierProvider<AppStateController>.value(
+      value: locator<AppStateController>(),
       child: const MyApp(),
     ),
   );

--- a/lib/presentation/auth/auth_gate.dart
+++ b/lib/presentation/auth/auth_gate.dart
@@ -24,7 +24,7 @@ class AuthGate extends StatelessWidget {
         }
         if (snapshot.hasData) {
           return ChangeNotifierProvider(
-            create: (_) => search.SearchController(locator()),
+            create: (_) => locator<search.SearchController>(),
             child: const SearchScreen(),
           );
         }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -23,7 +23,7 @@ final Map<String, WidgetBuilder> appRoutes = {
   '/register':(context) => const RegisterScreen(),
   '/notifications': (_) => const NotificationsScreen(),
   '/search': (_) => ChangeNotifierProvider(
-        create: (_) => search.SearchController(locator()),
+        create: (_) => locator<search.SearchController>(),
         child: const SearchScreen(),
       ),
   '/profile': (_)       => const ProfileScreen(),

--- a/test/application/app_state_controller_test.dart
+++ b/test/application/app_state_controller_test.dart
@@ -1,9 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:swappy/application/app_state_controller.dart';
 import 'package:swappy/models/exchange_request.dart';
+import 'package:swappy/infrastructure/di/locator.dart';
 
 void main() {
-  final appState = AppStateController();
+  late AppStateController appState;
+
+  setUpAll(() {
+    setupLocator();
+    appState = locator<AppStateController>();
+  });
 
   test('getReceivedRequests returns unique pending requests for current user', () {
     final received = appState.getReceivedRequests();

--- a/test/application/search_controller_test.dart
+++ b/test/application/search_controller_test.dart
@@ -9,7 +9,7 @@ void main() {
   });
 
   test('search transitions to success', () async {
-    final controller = SearchController(locator());
+    final controller = locator<SearchController>();
     await controller.search(
       from: 'a',
       to: 'b',


### PR DESCRIPTION
## Summary
- register `AppStateController` and `SearchController` in service locator
- replace direct controller instantiations with `locator` lookups
- document core dependencies for contributors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bb13ef708329a246563fe4594a34