### PR TITLE
Add splash screen and set as initial route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
-import 'app.dart';
-import 'infrastructure/di/locator.dart';
-import 'firebase_options.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:provider/provider.dart';
+
 import 'application/app_state_controller.dart';
+import 'firebase_options.dart';
+import 'infrastructure/di/locator.dart';
+import 'presentation/splash/splash_screen.dart';
+import 'routes.dart';
+import 'ui/theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -15,7 +20,32 @@ void main() async {
   runApp(
     ChangeNotifierProvider<AppStateController>.value(
       value: locator<AppStateController>(),
-      child: const MyApp(),
+      child: const SwappyApp(),
     ),
   );
+}
+
+class SwappyApp extends StatelessWidget {
+  const SwappyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+      debugShowCheckedModeBanner: false,
+      theme: appTheme(),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('es'),
+      ],
+      home: const SplashScreen(),
+      routes: appRoutes,
+    );
+  }
 }

--- a/lib/presentation/splash/splash_screen.dart
+++ b/lib/presentation/splash/splash_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../application/search/search_controller.dart' as search;
+import '../../constants/app_colors.dart';
+import '../../infrastructure/di/locator.dart';
+import '../search/search_screen.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 3), () {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ChangeNotifierProvider(
+            create: (_) => locator<search.SearchController>(),
+            child: const SearchScreen(),
+          ),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.flight_takeoff,
+              size: 100,
+              color: AppColors.primary,
+            ),
+            SizedBox(height: 24),
+            CircularProgressIndicator(
+              color: AppColors.primary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add timed splash screen with logo and progress indicator
- start app at splash screen before navigating to search form

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c488014c8329bb1e3a7a657ebdd7