### PR TITLE
feat: add firebase auth and google sign in

### DIFF
--- a/lib/infrastructure/auth/auth_service.dart
+++ b/lib/infrastructure/auth/auth_service.dart
@@ -1,9 +1,8 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart'; // para debugPrint
-
 abstract class AuthService {
   Future<UserCredential> signInWithEmail(String email, String password);
   Future<UserCredential> signUpWithEmail(String email, String password);
+  Future<UserCredential> signInWithGoogle();
   Future<void> signOut();
   Stream<User?> authStateChanges();
   User? get currentUser;
@@ -18,63 +17,3 @@ class AuthException implements Exception {
   String toString() => '$code: $message';
 }
 
-class FirebaseAuthService implements AuthService {
-  final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
-
-  @override
-  Stream<User?> authStateChanges() => _firebaseAuth.authStateChanges();
-
-  @override
-  User? get currentUser => _firebaseAuth.currentUser;
-
-  @override
-  Future<UserCredential> signInWithEmail(String email, String password) async {
-    try {
-      return await _firebaseAuth.signInWithEmailAndPassword(
-        email: email.trim(),            // <-- trim
-        password: password.trim(),      // <-- trim
-      );
-    } on FirebaseAuthException catch (e) {
-      debugPrint('SIGNIN ERROR code=${e.code} message=${e.message}');
-      throw AuthException(_mapError(e.code), code: e.code); // <-- conserva code
-    }
-  }
-
-  @override
-  Future<UserCredential> signUpWithEmail(String email, String password) async {
-    try {
-      return await _firebaseAuth.createUserWithEmailAndPassword(
-        email: email.trim(),            // <-- trim
-        password: password.trim(),      // <-- trim
-      );
-    } on FirebaseAuthException catch (e) {
-      debugPrint('SIGNUP ERROR code=${e.code} message=${e.message}');
-      throw AuthException(_mapError(e.code), code: e.code); // <-- conserva code
-    }
-  }
-
-  @override
-  Future<void> signOut() => _firebaseAuth.signOut();
-
-  String _mapError(String code) {
-    switch (code) {
-      case 'email-already-in-use':
-        return 'That email is already registered';
-      case 'invalid-email':
-        return 'Invalid email address';
-      case 'weak-password':
-        return 'Password too weak (min. 6 characters)';
-      case 'user-not-found':
-      case 'wrong-password':
-        return 'Invalid credentials';
-      case 'operation-not-allowed':
-        return 'This sign-in method is not enabled in Firebase';
-      case 'too-many-requests':
-        return 'Too many attempts. Please try again later';
-      case 'network-request-failed':
-        return 'Network error. Check your connection';
-      default:
-        return 'An error occurred, please try again';
-    }
-  }
-}

--- a/lib/infrastructure/auth/firebase_auth_service.dart
+++ b/lib/infrastructure/auth/firebase_auth_service.dart
@@ -1,0 +1,95 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import 'auth_service.dart';
+
+class FirebaseAuthService implements AuthService {
+  final FirebaseAuth _firebaseAuth;
+  final GoogleSignIn _googleSignIn;
+
+  FirebaseAuthService(this._firebaseAuth, this._googleSignIn);
+
+  @override
+  Stream<User?> authStateChanges() => _firebaseAuth.authStateChanges();
+
+  @override
+  User? get currentUser => _firebaseAuth.currentUser;
+
+  @override
+  Future<UserCredential> signInWithEmail(String email, String password) async {
+    try {
+      return await _firebaseAuth.signInWithEmailAndPassword(
+        email: email.trim(),
+        password: password.trim(),
+      );
+    } on FirebaseAuthException catch (e) {
+      debugPrint('SIGNIN ERROR code=${e.code} message=${e.message}');
+      throw AuthException(_mapError(e.code), code: e.code);
+    }
+  }
+
+  @override
+  Future<UserCredential> signUpWithEmail(String email, String password) async {
+    try {
+      return await _firebaseAuth.createUserWithEmailAndPassword(
+        email: email.trim(),
+        password: password.trim(),
+      );
+    } on FirebaseAuthException catch (e) {
+      debugPrint('SIGNUP ERROR code=${e.code} message=${e.message}');
+      throw AuthException(_mapError(e.code), code: e.code);
+    }
+  }
+
+  @override
+  Future<UserCredential> signInWithGoogle() async {
+    try {
+      final googleUser = await _googleSignIn.signIn();
+      if (googleUser == null) {
+        throw AuthException('Sign in aborted by user', code: 'canceled');
+      }
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+      return await _firebaseAuth.signInWithCredential(credential);
+    } on FirebaseAuthException catch (e) {
+      debugPrint('GOOGLE SIGNIN ERROR code=${e.code} message=${e.message}');
+      throw AuthException(_mapError(e.code), code: e.code);
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    await Future.wait([
+      _firebaseAuth.signOut(),
+      _googleSignIn.signOut(),
+      _googleSignIn.disconnect(),
+    ]);
+  }
+
+  String _mapError(String code) {
+    switch (code) {
+      case 'email-already-in-use':
+        return 'That email is already registered';
+      case 'invalid-email':
+        return 'Invalid email address';
+      case 'weak-password':
+        return 'Password too weak (min. 6 characters)';
+      case 'user-not-found':
+      case 'wrong-password':
+        return 'Invalid credentials';
+      case 'operation-not-allowed':
+        return 'This sign-in method is not enabled in Firebase';
+      case 'too-many-requests':
+        return 'Too many attempts. Please try again later';
+      case 'network-request-failed':
+        return 'Network error. Check your connection';
+      default:
+        return 'An error occurred, please try again';
+    }
+  }
+}
+

--- a/lib/infrastructure/di/locator.dart
+++ b/lib/infrastructure/di/locator.dart
@@ -1,16 +1,20 @@
 import 'package:get_it/get_it.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 
 import '../../domain/repositories/search_repository.dart';
 import '../../application/app_state_controller.dart';
 import '../../application/search/search_controller.dart';
 import '../repositories/mock_search_repository.dart';
 import '../auth/auth_service.dart';
+import '../auth/firebase_auth_service.dart';
 
 final locator = GetIt.instance;
 
 void setupLocator() {
   locator.registerLazySingleton<AppStateController>(() => AppStateController());
   locator.registerLazySingleton<SearchRepository>(() => MockSearchRepository());
-  locator.registerLazySingleton<AuthService>(() => FirebaseAuthService());
+  locator.registerLazySingleton<AuthService>(() =>
+      FirebaseAuthService(FirebaseAuth.instance, GoogleSignIn()));
   locator.registerFactory<SearchController>(() => SearchController(locator()));
 }

--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -63,6 +63,36 @@ class _LoginScreenState extends State<LoginScreen> {
     }
   }
 
+  Future<void> _signInWithGoogle() async {
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      await auth.signInWithGoogle();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Sesión iniciada')),
+      );
+      Navigator.of(context).pushAndRemoveUntil(
+        FadePageRoute(page: const AuthGate()),
+        (_) => false,
+      );
+    } on AuthException catch (e) {
+      debugPrint('GOOGLE SIGNIN ERROR => ${e.code}: ${e.message}');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${e.message} (${e.code})')),
+      );
+    } catch (e, st) {
+      debugPrint('GOOGLE SIGNIN UNEXPECTED ERROR => $e\n$st');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Ha ocurrido un error inesperado')),
+      );
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
   void _forgotPassword() {
     showDialog(
       context: context,
@@ -206,6 +236,16 @@ class _LoginScreenState extends State<LoginScreen> {
                                         color: Colors.white, fontSize: 16),
                                   ),
                           ),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 50,
+                        child: FilledButton.icon(
+                          onPressed: _loading ? null : _signInWithGoogle,
+                          icon: const Icon(Icons.g_mobiledata),
+                          label: const Text('Continue with Google'),
                         ),
                       ),
                       const SizedBox(height: 8),

--- a/lib/presentation/search/search_screen.dart
+++ b/lib/presentation/search/search_screen.dart
@@ -9,7 +9,6 @@ import '../../constants/dates.dart';
 import '../../domain/entities/search_result.dart';
 import '../../infrastructure/di/locator.dart';
 import '../../infrastructure/auth/auth_service.dart';
-import '../auth/auth_gate.dart';
 import '../widgets/destination_carousel.dart';
 import '../widgets/adaptive_scaffold.dart';
 import '../widgets/search_form.dart';
@@ -131,13 +130,7 @@ class _SearchScreenState extends State<SearchScreen> {
               ),
               actions: [
                 IconButton(
-                  onPressed: () {
-                    locator<AuthService>().signOut();
-                    Navigator.of(context).pushAndRemoveUntil(
-                      MaterialPageRoute(builder: (_) => const AuthGate()),
-                      (_) => false,
-                    );
-                  },
+                  onPressed: () => locator<AuthService>().signOut(),
                   icon: Icon(
                     Icons.logout,
                     color: Theme.of(context).colorScheme.onBackground,


### PR DESCRIPTION
## Summary
- add FirebaseAuthService with Google sign-in and full logout
- register auth service in service locator
- expose Google login buttons and logout action

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a499558ac0832992ae19ad020dc6b1