### PR TITLE
Add password reset, email verification, and user avatar

### DIFF
--- a/lib/infrastructure/auth/auth_service.dart
+++ b/lib/infrastructure/auth/auth_service.dart
@@ -1,0 +1,90 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class AuthException implements Exception {
+  final String message;
+  final String? code;
+  AuthException(this.message, {this.code});
+
+  @override
+  String toString() => 'AuthException(code: ' + (code ?? 'unknown') + ', message: ' + message + ')';
+}
+
+abstract class AuthService {
+  Future<UserCredential> signInWithEmail(String email, String password);
+  Future<UserCredential> signUpWithEmail(String email, String password);
+  Future<UserCredential> signInWithGoogle();
+  Future<void> signOut();
+  Future<void> sendPasswordResetEmail(String email);
+  Future<void> sendEmailVerification();
+  Future<User?> reloadUser();
+}
+
+class FirebaseAuthService implements AuthService {
+  final FirebaseAuth _auth;
+  final GoogleSignIn _google;
+
+  FirebaseAuthService(this._auth, this._google);
+
+  Future<T> _wrap<T>(Future<T> Function() fn) async {
+    try {
+      return await fn();
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.message ?? 'Auth error', code: e.code);
+    }
+  }
+
+  @override
+  Future<UserCredential> signInWithEmail(String email, String password) {
+    return _wrap(() => _auth.signInWithEmailAndPassword(email: email, password: password));
+  }
+
+  @override
+  Future<UserCredential> signUpWithEmail(String email, String password) {
+    return _wrap(() => _auth.createUserWithEmailAndPassword(email: email, password: password));
+  }
+
+  @override
+  Future<UserCredential> signInWithGoogle() async {
+    return _wrap(() async {
+      final googleUser = await _google.signIn();
+      if (googleUser == null) {
+        throw AuthException('Sign in aborted', code: 'aborted');
+      }
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+      return _auth.signInWithCredential(credential);
+    });
+  }
+
+  @override
+  Future<void> signOut() {
+    return _wrap(() async {
+      await _google.signOut();
+      await _auth.signOut();
+    });
+  }
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) {
+    return _wrap(() => _auth.sendPasswordResetEmail(email: email));
+  }
+
+  @override
+  Future<void> sendEmailVerification() async {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw AuthException('No user', code: 'no-user');
+    }
+    await _wrap(() => user.sendEmailVerification());
+  }
+
+  @override
+  Future<User?> reloadUser() async {
+    await _auth.currentUser?.reload();
+    return _auth.currentUser;
+  }
+}

--- a/lib/infrastructure/di/locator.dart
+++ b/lib/infrastructure/di/locator.dart
@@ -1,0 +1,13 @@
+import 'package:get_it/get_it.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import '../auth/auth_service.dart';
+
+final locator = GetIt.instance;
+
+void setupLocator() {
+  locator.registerLazySingleton<AuthService>(
+    () => FirebaseAuthService(FirebaseAuth.instance, GoogleSignIn()),
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'app.dart';
+import 'infrastructure/di/locator.dart';
 
 void main() {
+  setupLocator();
   runApp(const MyApp());
 }

--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+
+import '../../infrastructure/di/locator.dart';
+import '../../infrastructure/auth/auth_service.dart';
+import 'register_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _signInWithEmail() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      await auth.signInWithEmail(
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+    } on AuthException catch (e) {
+      _showError('${e.message} (${e.code})');
+    } catch (e) {
+      _showError(e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _signInWithGoogle() async {
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      await auth.signInWithGoogle();
+    } on AuthException catch (e) {
+      _showError('${e.message} (${e.code})');
+    } catch (e) {
+      _showError(e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _forgotPassword() async {
+    final auth = locator<AuthService>();
+    final ctrl = TextEditingController(text: _emailController.text.trim());
+    final email = await showDialog<String?>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reset password'),
+        content: TextField(
+          controller: ctrl,
+          decoration: const InputDecoration(
+            labelText: 'Email',
+            hintText: 'you@example.com',
+          ),
+          keyboardType: TextInputType.emailAddress,
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, null), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, ctrl.text.trim()), child: const Text('Send')),
+        ],
+      ),
+    );
+    if (email == null || email.isEmpty) return;
+    try {
+      await auth.sendPasswordResetEmail(email);
+      _showSnack('Password reset email sent to $email');
+    } on AuthException catch (e) {
+      _showError('${e.message} (${e.code})');
+    } catch (e) {
+      _showError(e.toString());
+    }
+  }
+
+  void _showError(String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  void _showSnack(String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const spacing = 16.0;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Iniciar sesión')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 480),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _emailController,
+                    textInputAction: TextInputAction.next,
+                    keyboardType: TextInputType.emailAddress,
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      hintText: 'tucorreo@ejemplo.com',
+                    ),
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) return 'Introduce tu email';
+                      if (!v.contains('@')) return 'Email inválido';
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _passwordController,
+                    obscureText: true,
+                    textInputAction: TextInputAction.done,
+                    onFieldSubmitted: (_) => _signInWithEmail(),
+                    decoration: const InputDecoration(labelText: 'Contraseña'),
+                    validator: (v) {
+                      if (v == null || v.isEmpty) return 'Introduce tu contraseña';
+                      if (v.length < 6) return 'Mínimo 6 caracteres';
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: _loading ? null : _forgotPassword,
+                      child: const Text('¿Has olvidado tu contraseña?'),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: _loading ? null : _signInWithEmail,
+                      child: _loading
+                          ? const Padding(
+                              padding: EdgeInsets.symmetric(vertical: 8),
+                              child: SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2)),
+                            )
+                          : const Text('Entrar'),
+                    ),
+                  ),
+                  SizedBox(height: spacing),
+                  const Divider(),
+                  SizedBox(height: spacing),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      icon: const Icon(Icons.login),
+                      label: const Text('Continue with Google'),
+                      onPressed: _loading ? null : _signInWithGoogle,
+                    ),
+                  ),
+                  SizedBox(height: spacing),
+                  TextButton(
+                    onPressed: _loading
+                        ? null
+                        : () {
+                            Navigator.of(context).push(MaterialPageRoute(builder: (_) => const RegisterScreen()));
+                          },
+                    child: const Text('¿No tienes cuenta? Crear una'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/auth/register_screen.dart
+++ b/lib/presentation/auth/register_screen.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+
+import '../../infrastructure/di/locator.dart';
+import '../../infrastructure/auth/auth_service.dart';
+import 'verify_email_screen.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey  = GlobalKey<FormState>();
+  final _name     = TextEditingController();
+  final _email    = TextEditingController();
+  final _password = TextEditingController();
+  final _confirm  = TextEditingController();
+  bool _obscure = true;
+  bool _acceptTerms = false;
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _email.dispose();
+    _password.dispose();
+    _confirm.dispose();
+    super.dispose();
+  }
+
+  void _showSnack(String msg) =>
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+
+  Future<void> _submitEmail() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    if (!_acceptTerms) {
+      _showSnack('Debes aceptar los términos y condiciones');
+      return;
+    }
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      await auth.signUpWithEmail(_email.text.trim(), _password.text);
+      await auth.sendEmailVerification();
+      if (!mounted) return;
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => const VerifyEmailScreen()),
+      );
+    } on AuthException catch (e) {
+      _showSnack('${e.message} (${e.code})');
+    } catch (e) {
+      _showSnack(e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _signInWithGoogle() async {
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      await auth.signInWithGoogle();
+      // AuthGate will route
+    } on AuthException catch (e) {
+      _showSnack('${e.message} (${e.code})');
+    } catch (e) {
+      _showSnack(e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const spacing = 16.0;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Crear cuenta')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  TextFormField(
+                    controller: _name,
+                    decoration: const InputDecoration(labelText: 'Nombre'),
+                    validator: (v) => (v == null || v.trim().isEmpty) ? 'Introduce tu nombre' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _email,
+                    decoration: const InputDecoration(labelText: 'Email'),
+                    keyboardType: TextInputType.emailAddress,
+                    validator: (v) {
+                      if (v == null || v.trim().isEmpty) return 'Introduce tu email';
+                      if (!v.contains('@')) return 'Email inválido';
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _password,
+                    decoration: const InputDecoration(labelText: 'Contraseña'),
+                    obscureText: _obscure,
+                    validator: (v) {
+                      if (v == null || v.isEmpty) return 'Introduce tu contraseña';
+                      if (v.length < 6) return 'Mínimo 6 caracteres';
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _confirm,
+                    decoration: const InputDecoration(labelText: 'Confirmar contraseña'),
+                    obscureText: _obscure,
+                    validator: (v) => (v != _password.text) ? 'Las contraseñas no coinciden' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  CheckboxListTile(
+                    value: _acceptTerms,
+                    onChanged: (v) => setState(() => _acceptTerms = v ?? false),
+                    title: const Text('Acepto los términos y la política de privacidad'),
+                    controlAffinity: ListTileControlAffinity.leading,
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: _loading ? null : _submitEmail,
+                      child: _loading
+                          ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                          : const Text('Crear cuenta'),
+                    ),
+                  ),
+                  SizedBox(height: spacing),
+                  const Divider(),
+                  SizedBox(height: spacing),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      icon: const Icon(Icons.login),
+                      label: const Text('Continue with Google'),
+                      onPressed: _loading ? null : _signInWithGoogle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/auth/verify_email_screen.dart
+++ b/lib/presentation/auth/verify_email_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import '../../infrastructure/di/locator.dart';
+import '../../infrastructure/auth/auth_service.dart';
+
+class VerifyEmailScreen extends StatefulWidget {
+  const VerifyEmailScreen({super.key});
+
+  @override
+  State<VerifyEmailScreen> createState() => _VerifyEmailScreenState();
+}
+
+class _VerifyEmailScreenState extends State<VerifyEmailScreen> {
+  bool _loading = false;
+
+  void _show(String msg) =>
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+
+  Future<void> _resend() async {
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      await auth.sendEmailVerification();
+      _show('Verification email sent');
+    } on AuthException catch (e) {
+      _show('${e.message} (${e.code})');
+    } catch (e) {
+      _show(e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _loading = true);
+    final auth = locator<AuthService>();
+    try {
+      final user = await auth.reloadUser();
+      if (user != null && user.emailVerified) {
+        if (!mounted) return;
+        Navigator.of(context).pop(); // go back to gate
+      } else {
+        _show('Not verified yet. Please check your email.');
+      }
+    } on AuthException catch (e) {
+      _show('${e.message} (${e.code})');
+    } catch (e) {
+      _show(e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const spacing = 16.0;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Verify your email')),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'We emailed you a verification link. Please verify your email to continue.',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: spacing),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    FilledButton(
+                      onPressed: _loading ? null : _resend,
+                      child: const Text('Resend'),
+                    ),
+                    const SizedBox(width: 12),
+                    OutlinedButton(
+                      onPressed: _loading ? null : _refresh,
+                      child: const Text('I have verified'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -4,6 +4,9 @@ import 'package:swappy/screens/notifications_screen.dart';
 import 'package:swappy/screens/search_screen.dart';
 import 'package:swappy/screens/splash_screen.dart';
 import 'package:swappy/screens/profile_screen.dart';
+import 'package:swappy/presentation/auth/login_screen.dart';
+import 'package:swappy/presentation/auth/register_screen.dart';
+import 'package:swappy/presentation/auth/verify_email_screen.dart';
 
 final Map<String, WidgetBuilder> appRoutes = {
   '/': (_)             => const SplashScreen(),
@@ -11,4 +14,7 @@ final Map<String, WidgetBuilder> appRoutes = {
   '/search': (_)        => const SearchScreen(),
   '/profile': (_)       => const ProfileScreen(),
   '/create': (_)        => const CreateListingScreen(),
+  '/login': (_)         => const LoginScreen(),
+  '/register': (_)      => const RegisterScreen(),
+  '/verify-email': (_)  => const VerifyEmailScreen(),
 };

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../infrastructure/di/locator.dart';
+import '../infrastructure/auth/auth_service.dart';
 import '../widgets/main_scaffold.dart';
 import '../widgets/search_form.dart';
 import '../widgets/search_summary.dart';
@@ -88,11 +91,36 @@ class _SearchScreenState extends State<SearchScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    final name = user?.displayName ?? 'User';
+    final photo = user?.photoURL;
     final screenWidth = MediaQuery.of(context).size.width;
 
     return MainScaffold(
       currentIndex: 1,
       child: Scaffold(
+        appBar: AppBar(
+          title: Row(
+            children: [
+              CircleAvatar(
+                radius: 16,
+                backgroundImage: (photo != null) ? NetworkImage(photo) : null,
+                child: (photo == null) ? Text(name.isNotEmpty ? name[0] : '?') : null,
+              ),
+              const SizedBox(width: 8),
+              Text(name),
+            ],
+          ),
+          actions: [
+            IconButton(
+              tooltip: 'Cerrar sesión',
+              icon: const Icon(Icons.logout),
+              onPressed: () async {
+                await locator<AuthService>().signOut();
+              },
+            ),
+          ],
+        ),
         backgroundColor: Colors.white,
         floatingActionButton: FloatingActionButton(
           heroTag: "search",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   intl: ^0.20.2
   cupertino_icons: ^1.0.8
   uuid: ^4.0.0
+  firebase_core: ^2.28.0
+  firebase_auth: ^4.17.8
+  google_sign_in: ^6.1.6
+  get_it: ^7.6.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- extend auth service with password reset, email verification, and reload APIs
- add login/register/verify email screens with Google sign-in support
- show signed-in user avatar with logout on search screen

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b1fb302c8329971cb35f4d131969