### PR TITLE
Refactor FirebaseAuth service and add password reset

### DIFF
--- a/lib/infrastructure/auth/auth_service.dart
+++ b/lib/infrastructure/auth/auth_service.dart
@@ -1,13 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:google_sign_in/google_sign_in.dart';
 
-/// Interfaz de autenticación
+/// Authentication interface
 abstract class AuthService {
-  // Flujo del estado de auth
+  // Auth state
   Stream<User?> authStateChanges();
-
-  // Usuario actual (o null)
   User? get currentUser;
 
   // Email/Password
@@ -17,137 +13,18 @@ abstract class AuthService {
   // Google
   Future<UserCredential> signInWithGoogle();
 
-  // 🔹 Restablecer contraseña (NUEVO)
+  // Password reset
   Future<void> sendPasswordResetEmail(String email);
 
-  // Cerrar sesión (completa)
+  // Sign out
   Future<void> signOut();
 }
 
-/// Excepción de dominio para mostrar mensajes controlados en la UI
+/// Domain exception to surface friendly messages to the UI
 class AuthException implements Exception {
   final String code;
   final String message;
   AuthException(this.message, {this.code = 'unknown'});
-
   @override
   String toString() => 'AuthException($code): $message';
-}
-
-/// Implementación real con Firebase + Google
-class FirebaseAuthService implements AuthService {
-  final FirebaseAuth _auth;
-  final GoogleSignIn _google;
-
-  FirebaseAuthService({
-    FirebaseAuth? auth,
-    GoogleSignIn? googleSignIn,
-  })  : _auth = auth ?? FirebaseAuth.instance,
-        _google = googleSignIn ?? GoogleSignIn();
-
-  // --- Public API ---
-
-  @override
-  Stream<User?> authStateChanges() => _auth.authStateChanges();
-
-  @override
-  User? get currentUser => _auth.currentUser;
-
-  @override
-  Future<UserCredential> signInWithEmail(String email, String password) {
-    return _wrapFirebase(() => _auth.signInWithEmailAndPassword(
-          email: email,
-          password: password,
-        ));
-  }
-
-  @override
-  Future<UserCredential> signUpWithEmail(String email, String password) {
-    return _wrapFirebase(() => _auth.createUserWithEmailAndPassword(
-          email: email,
-          password: password,
-        ));
-  }
-
-  @override
-  Future<UserCredential> signInWithGoogle() async {
-    if (kIsWeb) {
-      // WEB: usar popup de Firebase
-      final provider = GoogleAuthProvider();
-      provider.setCustomParameters({'prompt': 'select_account'});
-      return _wrapFirebase(() => _auth.signInWithPopup(provider));
-    } else {
-      // ANDROID / iOS: flujo nativo con google_sign_in
-      final googleUser = await _google.signIn();
-      if (googleUser == null) {
-        throw AuthException('Inicio de sesión cancelado por el usuario', code: 'aborted');
-      }
-      final googleAuth = await googleUser.authentication;
-      final credential = GoogleAuthProvider.credential(
-        accessToken: googleAuth.accessToken,
-        idToken: googleAuth.idToken,
-      );
-      return _wrapFirebase(() => _auth.signInWithCredential(credential));
-    }
-  }
-
-  // 🔹 Restablecer contraseña (NUEVO)
-  @override
-  Future<void> sendPasswordResetEmail(String email) {
-    return _wrapFirebase(() => _auth.sendPasswordResetEmail(email: email.trim()));
-  }
-
-  @override
-  Future<void> signOut() async {
-    // Cerrar sesión COMPLETA: Firebase + Google (en móvil)
-    await _auth.signOut();
-    if (!kIsWeb) {
-      try {
-        await _google.signOut();
-      } catch (_) {}
-      try {
-        await _google.disconnect();
-      } catch (_) {}
-    }
-  }
-
-  // --- Helpers ---
-
-  Future<T> _wrapFirebase<T>(Future<T> Function() run) async {
-    try {
-      return await run();
-    } on FirebaseAuthException catch (e) {
-      // Mapeamos a nuestra excepción de dominio con mensajes amigables
-      throw AuthException(_messageForCode(e.code), code: e.code);
-    } catch (_) {
-      throw AuthException('Ha ocurrido un error inesperado', code: 'unknown');
-    }
-  }
-
-  String _messageForCode(String code) {
-    switch (code) {
-      case 'aborted':
-        return 'Inicio de sesión cancelado';
-      case 'user-not-found':
-      case 'wrong-password':
-      case 'invalid-credential':
-        return 'Credenciales inválidas';
-      case 'email-already-in-use':
-        return 'Este email ya está registrado';
-      case 'weak-password':
-        return 'La contraseña es demasiado débil';
-      case 'operation-not-allowed':
-        return 'Método de inicio de sesión no habilitado';
-      case 'too-many-requests':
-        return 'Demasiados intentos. Inténtalo más tarde';
-      case 'network-request-failed':
-        return 'Error de red. Revisa tu conexión';
-      case 'popup-closed-by-user':
-        return 'Se cerró la ventana de Google';
-      case 'unauthorized-domain':
-        return 'Dominio no autorizado en Firebase (Web)';
-      default:
-        return 'Ha ocurrido un error inesperado';
-    }
-  }
 }

--- a/lib/infrastructure/auth/firebase_auth_service.dart
+++ b/lib/infrastructure/auth/firebase_auth_service.dart
@@ -1,110 +1,115 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:google_sign_in/google_sign_in.dart';
 
 import 'auth_service.dart';
 
 class FirebaseAuthService implements AuthService {
-  final FirebaseAuth _firebaseAuth;
-  final GoogleSignIn _googleSignIn;
+  final FirebaseAuth _auth;
+  final GoogleSignIn _google;
 
-  FirebaseAuthService(this._firebaseAuth, this._googleSignIn);
+  FirebaseAuthService({
+    FirebaseAuth? auth,
+    GoogleSignIn? googleSignIn,
+  })  : _auth = auth ?? FirebaseAuth.instance,
+        _google = googleSignIn ?? GoogleSignIn();
+
+  // ---- Auth state ----
+  @override
+  Stream<User?> authStateChanges() => _auth.authStateChanges();
 
   @override
-  Stream<User?> authStateChanges() => _firebaseAuth.authStateChanges();
+  User? get currentUser => _auth.currentUser;
 
+  // ---- Email/Password ----
   @override
-  User? get currentUser => _firebaseAuth.currentUser;
-
-  @override
-  Future<UserCredential> signInWithEmail(String email, String password) async {
-    try {
-      return await _firebaseAuth.signInWithEmailAndPassword(
-        email: email.trim(),
-        password: password.trim(),
-      );
-    } on FirebaseAuthException catch (e) {
-      debugPrint('SIGNIN ERROR code=${e.code} message=${e.message}');
-      throw AuthException(_mapError(e.code), code: e.code);
-    }
+  Future<UserCredential> signInWithEmail(String email, String password) {
+    return _wrapFirebase(() => _auth.signInWithEmailAndPassword(
+          email: email,
+          password: password,
+        ));
   }
 
   @override
-  Future<UserCredential> signUpWithEmail(String email, String password) async {
-    try {
-      return await _firebaseAuth.createUserWithEmailAndPassword(
-        email: email.trim(),
-        password: password.trim(),
-      );
-    } on FirebaseAuthException catch (e) {
-      debugPrint('SIGNUP ERROR code=${e.code} message=${e.message}');
-      throw AuthException(_mapError(e.code), code: e.code);
-    }
+  Future<UserCredential> signUpWithEmail(String email, String password) {
+    return _wrapFirebase(() => _auth.createUserWithEmailAndPassword(
+          email: email,
+          password: password,
+        ));
   }
 
+  // ---- Google ----
   @override
   Future<UserCredential> signInWithGoogle() async {
-    try {
-      final googleUser = await _googleSignIn.signIn();
+    if (kIsWeb) {
+      final provider = GoogleAuthProvider();
+      provider.setCustomParameters({'prompt': 'select_account'});
+      return _wrapFirebase(() => _auth.signInWithPopup(provider));
+    } else {
+      final googleUser = await _google.signIn();
       if (googleUser == null) {
-        throw AuthException('Sign in aborted by user', code: 'canceled');
+        throw AuthException('Inicio de sesión cancelado por el usuario', code: 'aborted');
       }
       final googleAuth = await googleUser.authentication;
       final credential = GoogleAuthProvider.credential(
         accessToken: googleAuth.accessToken,
         idToken: googleAuth.idToken,
       );
-      return await _firebaseAuth.signInWithCredential(credential);
-    } on FirebaseAuthException catch (e) {
-      debugPrint('GOOGLE SIGNIN ERROR code=${e.code} message=${e.message}');
-      throw AuthException(_mapError(e.code), code: e.code);
+      return _wrapFirebase(() => _auth.signInWithCredential(credential));
     }
   }
 
+  // ---- Password reset ----
   @override
-  Future<void> signOut() async {
-    await Future.wait([
-      _firebaseAuth.signOut(),
-      _googleSignIn.signOut(),
-      _googleSignIn.disconnect(),
-    ]);
+  Future<void> sendPasswordResetEmail(String email) {
+    return _wrapFirebase(() => _auth.sendPasswordResetEmail(email: email.trim()));
   }
 
+  // ---- Sign out (complete) ----
   @override
-  Future<void> sendPasswordResetEmail(String email) async {
+  Future<void> signOut() async {
+    await _auth.signOut();
+    if (!kIsWeb) {
+      try { await _google.signOut(); } catch (_) {}
+      try { await _google.disconnect(); } catch (_) {}
+    }
+  }
+
+  // ---- Helpers ----
+  Future<T> _wrapFirebase<T>(Future<T> Function() run) async {
     try {
-      await _firebaseAuth.sendPasswordResetEmail(email: email.trim());
+      return await run();
     } on FirebaseAuthException catch (e) {
-      // Usa tu mapeo si lo tienes; aquí lanzamos un AuthException simple
-      throw AuthException(
-        e.message ?? 'Error al enviar el correo de recuperación',
-        code: e.code,
-      );
+      throw AuthException(_messageForCode(e.code), code: e.code);
     } catch (_) {
       throw AuthException('Ha ocurrido un error inesperado', code: 'unknown');
     }
   }
 
-  String _mapError(String code) {
+  String _messageForCode(String code) {
     switch (code) {
-      case 'email-already-in-use':
-        return 'That email is already registered';
-      case 'invalid-email':
-        return 'Invalid email address';
-      case 'weak-password':
-        return 'Password too weak (min. 6 characters)';
+      case 'aborted':
+        return 'Inicio de sesión cancelado';
       case 'user-not-found':
       case 'wrong-password':
-        return 'Invalid credentials';
+      case 'invalid-credential':
+        return 'Credenciales inválidas';
+      case 'email-already-in-use':
+        return 'Este email ya está registrado';
+      case 'weak-password':
+        return 'La contraseña es demasiado débil';
       case 'operation-not-allowed':
-        return 'This sign-in method is not enabled in Firebase';
+        return 'Método de inicio de sesión no habilitado';
       case 'too-many-requests':
-        return 'Too many attempts. Please try again later';
+        return 'Demasiados intentos. Inténtalo más tarde';
       case 'network-request-failed':
-        return 'Network error. Check your connection';
+        return 'Error de red. Revisa tu conexión';
+      case 'popup-closed-by-user':
+        return 'Se cerró la ventana de Google';
+      case 'unauthorized-domain':
+        return 'Dominio no autorizado en Firebase (Web)';
       default:
-        return 'An error occurred, please try again';
+        return 'Ha ocurrido un error inesperado';
     }
   }
 }
-

--- a/lib/infrastructure/di/locator.dart
+++ b/lib/infrastructure/di/locator.dart
@@ -5,7 +5,8 @@ import '../../application/app_state_controller.dart';
 import '../../application/search/search_controller.dart';
 import '../repositories/mock_search_repository.dart';
 
-import '../auth/auth_service.dart'; // contiene también FirebaseAuthService
+import '../auth/auth_service.dart';
+import '../auth/firebase_auth_service.dart';
 
 final locator = GetIt.instance;
 
@@ -17,7 +18,9 @@ void setupLocator() {
   locator.registerLazySingleton<SearchRepository>(() => MockSearchRepository());
 
   // Auth
-  locator.registerLazySingleton<AuthService>(() => FirebaseAuthService());
+  if (!locator.isRegistered<AuthService>()) {
+    locator.registerLazySingleton<AuthService>(() => FirebaseAuthService());
+  }
 
   // Controllers
   locator.registerFactory<SearchController>(() => SearchController(locator()));


### PR DESCRIPTION
## Summary
- keep `AuthService` as interface with `AuthException`
- implement single `FirebaseAuthService` with password reset and improved sign out
- wire DI to use the new implementation

## Testing
- `dart format lib/infrastructure/auth/auth_service.dart lib/infrastructure/auth/firebase_auth_service.dart lib/infrastructure/di/locator.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bc566d788329860992963a27a4da